### PR TITLE
Feature | Use thiserror as Error provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,63 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "http-auth-basic"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
+ "thiserror",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "http-auth-basic"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base64",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-auth-basic"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-auth-basic"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 
 edition = "2018"
@@ -17,4 +17,5 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.12.0"
+base64 = "0.12"
+thiserror = "1.0"

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,4 +1,4 @@
-use crate::error::AuthBasicError;
+use crate::error::Error;
 
 /// A `struct` to represent the `user_id` and `password` fields
 /// from an _Authorization Basic_ header value
@@ -31,7 +31,7 @@ impl Credentials {
 
     /// Create a `Credentials` instance from a base64 `String`
     /// which must encode user credentials as `username:password`
-    pub fn decode(auth_header_value: String) -> Result<Self, AuthBasicError> {
+    pub fn decode(auth_header_value: String) -> Result<Self, Error> {
         let decoded = base64::decode(auth_header_value)?;
         let as_utf8 = String::from_utf8(decoded)?;
         let parts = as_utf8.split(':');
@@ -46,7 +46,7 @@ impl Credentials {
             return Ok(credentials);
         }
 
-        Err(AuthBasicError::InvalidAuthorizationHeader)
+        Err(Error::InvalidAuthorizationHeader)
     }
 
     /// Encode a `Credentials` instance into a base64 `String`
@@ -58,21 +58,21 @@ impl Credentials {
 
     /// Creates a `Credentials` instance from an HTTP Authorization header
     /// which schema is a valid `Basic` HTTP Authorization Schema.
-    pub fn from_header(auth_header: String) -> Result<Credentials, AuthBasicError> {
+    pub fn from_header(auth_header: String) -> Result<Credentials, Error> {
         // check if its a valid basic auth header
         let parts = auth_header.split(' ');
         let parts: Vec<String> = parts.map(|part| part.to_string()).collect();
 
         if parts.len() > 2 {
             // invalid authorization token received
-            return Err(AuthBasicError::InvalidAuthorizationHeader);
+            return Err(Error::InvalidAuthorizationHeader);
         }
 
         if let Some(auth_type) = parts.get(0) {
             // check the provided authorization header
             // to be a "Basic" authorization header
             if auth_type.to_lowercase() != "basic" {
-                return Err(AuthBasicError::InvalidScheme(auth_type.to_string()));
+                return Err(Error::InvalidScheme(auth_type.to_string()));
             }
         }
 
@@ -82,7 +82,7 @@ impl Credentials {
             return Ok(credentials);
         }
 
-        Err(AuthBasicError::InvalidAuthorizationHeader)
+        Err(Error::InvalidAuthorizationHeader)
     }
 
     /// Creates a HTTP Authorization header value for the basic schema

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,50 +1,34 @@
 use base64::DecodeError;
-use std::fmt;
 use std::string::FromUtf8Error;
+use thiserror::Error as ThisError;
 
 /// Authorization Header Error
-#[derive(Debug)]
-pub enum AuthBasicError {
+#[derive(Debug, ThisError)]
+pub enum Error {
     /// The HTTP Authorization header value is invalid
+    #[error("Invalid authorization header provided")]
     InvalidAuthorizationHeader,
     /// The HTTP Authorization header contains a valid
     /// value but the scheme is other than `Basic`
+    #[error("Inavlid authorization header scheme, {0}")]
     InvalidScheme(String),
     /// The value expected as a base64 encoded `String` is not
     /// encoded correctly
+    #[error("Invalid Base64 provided, {0}")]
     InvalidBase64Value(String),
     /// The provided binary is not a valid UTF-8 character
+    #[error("The provided value is not a valid UTF-8")]
     InvalidUTF8Value(String),
 }
 
-impl fmt::Display for AuthBasicError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            AuthBasicError::InvalidAuthorizationHeader => write!(
-                f,
-                "Invalid value provided for the HTTP Authorization header"
-            ),
-            AuthBasicError::InvalidScheme(scheme) => {
-                write!(f, "The scheme provided ({}) is not Basic", scheme)
-            }
-            AuthBasicError::InvalidBase64Value(message) => {
-                write!(f, "The value have an invalid base64 encoding\n{}", message)
-            }
-            AuthBasicError::InvalidUTF8Value(message) => {
-                write!(f, "Invalid UTF-8 Provided\n{}", message)
-            }
-        }
-    }
-}
-
-impl From<DecodeError> for AuthBasicError {
+impl From<DecodeError> for Error {
     fn from(decode_error: DecodeError) -> Self {
-        AuthBasicError::InvalidBase64Value(decode_error.to_string())
+        Self::InvalidBase64Value(decode_error.to_string())
     }
 }
 
-impl From<FromUtf8Error> for AuthBasicError {
+impl From<FromUtf8Error> for Error {
     fn from(utf8_err: FromUtf8Error) -> Self {
-        AuthBasicError::InvalidUTF8Value(utf8_err.to_string())
+        Self::InvalidUTF8Value(utf8_err.to_string())
     }
 }


### PR DESCRIPTION
Makes use of `thiserror` crate as error provider to improve development
experience on the API.