### PR TITLE
Support passwords with colons compliant with RFC 2617 spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "http-auth-basic"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "http-auth-basic"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-auth-basic"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 
 edition = "2018"

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -35,7 +35,12 @@ impl Credentials {
         let decoded = base64::decode(auth_header_value)?;
         let as_utf8 = String::from_utf8(decoded)?;
         let parts = as_utf8.split(':');
-        let parts: Vec<String> = parts.map(|p| p.to_string()).collect();
+        let mut parts: Vec<String> = parts.map(|p| p.to_string()).collect();
+
+        // RFC 2617 provides support for passwords with colons
+        if parts.len() > 2 {
+            parts = vec![parts[0].clone(), parts[1..].join(":")];
+        }
 
         if parts.len() == 2 {
             let credentials = Credentials {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,11 @@ mod tests {
 
     #[test]
     fn it_creates_credentials_from_value_with_colon() {
-        let auth_header_value = String::from("dXNlcm5hbWU6cGFzczp3b3Jk");
+        let auth_header_value = String::from("dXNlcm5hbWU6OnBhc3M6d29yZDo=");
         let credentials = Credentials::decode(auth_header_value).unwrap();
 
         assert_eq!(credentials.user_id, String::from("username"));
-        assert_eq!(credentials.password, String::from("pass:word"));
+        assert_eq!(credentials.password, String::from(":pass:word:"));
     }
 
     #[test]
@@ -75,11 +75,11 @@ mod tests {
 
     #[test]
     fn it_creates_credentials_from_header_value_with_colon() {
-        let auth_header_value = String::from("Basic dXNlcm5hbWU6cGFzczp3b3Jk");
+        let auth_header_value = String::from("Basic dXNlcm5hbWU6OnBhc3M6d29yZDo=");
         let credentials = Credentials::from_header(auth_header_value).unwrap();
 
         assert_eq!(credentials.user_id, String::from("username"));
-        assert_eq!(credentials.password, String::from("pass:word"));
+        assert_eq!(credentials.password, String::from(":pass:word:"));
     }
 
     #[test]
@@ -92,9 +92,12 @@ mod tests {
 
     #[test]
     fn it_creates_header_value_with_colon() {
-        let credentials = Credentials::new("username", "pass:word");
+        let credentials = Credentials::new("username", ":pass:word:");
         let credentials = credentials.as_http_header();
 
-        assert_eq!(String::from("Basic dXNlcm5hbWU6cGFzczp3b3Jk"), credentials);
+        assert_eq!(
+            String::from("Basic dXNlcm5hbWU6OnBhc3M6d29yZDo="),
+            credentials
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,15 @@ mod tests {
     }
 
     #[test]
+    fn it_creates_credentials_from_value_with_colon() {
+        let auth_header_value = String::from("dXNlcm5hbWU6cGFzczp3b3Jk");
+        let credentials = Credentials::decode(auth_header_value).unwrap();
+
+        assert_eq!(credentials.user_id, String::from("username"));
+        assert_eq!(credentials.password, String::from("pass:word"));
+    }
+
+    #[test]
     fn it_encodes_credentials() {
         let credentials = Credentials::new("username", "password");
         let credentials = credentials.encode();
@@ -65,10 +74,27 @@ mod tests {
     }
 
     #[test]
+    fn it_creates_credentials_from_header_value_with_colon() {
+        let auth_header_value = String::from("Basic dXNlcm5hbWU6cGFzczp3b3Jk");
+        let credentials = Credentials::from_header(auth_header_value).unwrap();
+
+        assert_eq!(credentials.user_id, String::from("username"));
+        assert_eq!(credentials.password, String::from("pass:word"));
+    }
+
+    #[test]
     fn it_creates_header_value() {
         let credentials = Credentials::new("username", "password");
         let credentials = credentials.as_http_header();
 
         assert_eq!(String::from("Basic dXNlcm5hbWU6cGFzc3dvcmQ="), credentials);
+    }
+
+    #[test]
+    fn it_creates_header_value_with_colon() {
+        let credentials = Credentials::new("username", "pass:word");
+        let credentials = credentials.as_http_header();
+
+        assert_eq!(String::from("Basic dXNlcm5hbWU6cGFzczp3b3Jk"), credentials);
     }
 }


### PR DESCRIPTION
Hi there,

I came across a bug with the crate where passwords containing a colon caused it to return an `Err(AuthBasicError::InvalidAuthorizationHeader)`, even though [RFC 2617](https://tools.ietf.org/html/rfc2617) allows for colons to be present in the password (but not username).

This PR implements this support to align the crate with the spec. It also includes some simple tests to verify that the functionality works as intended.

Thanks!

Shane