### PR TITLE
Efficiency improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,4 +120,37 @@ mod tests {
         assert_eq!(credentials.user_id, String::from("username"));
         assert_eq!(credentials.password, String::from("password"));
     }
+
+    #[test]
+    fn from_header_returns_err_when_input_has_no_whitespace() {
+        let auth_header_value = String::from("BasicdXNlcm5hbWU6OnBhc3M6d29yZDo=");
+        let credentials = Credentials::from_header(auth_header_value);
+
+        assert!(credentials.is_err());
+    }
+
+    #[test]
+    fn from_header_returns_err_when_input_contains_multiple_whitespaces() {
+        let auth_header_value = String::from("Basic dXNlcm5hbWU6On Bhc3M6d29yZDo=");
+        let credentials = Credentials::from_header(auth_header_value);
+
+        assert!(credentials.is_err());
+    }
+
+    #[test]
+    fn from_header_returns_err_when_input_is_not_basic_auth() {
+        let auth_header_value = String::from("Bearer dXNlcm5hbWU6OnBhc3M6d29yZDo=");
+        let credentials = Credentials::from_header(auth_header_value);
+
+        assert!(credentials.is_err());
+    }
+
+    #[test]
+    fn decode_returns_err_when_input_has_no_colons() {
+        // base64::encode("usernamepassword") = "dXNlcm5hbWVwYXNzd29yZA==""
+        let auth_header_value = String::from("dXNlcm5hbWVwYXNzd29yZA==");
+        let credentials = Credentials::from_header(auth_header_value);
+
+        assert!(credentials.is_err());
+    }
 }


### PR DESCRIPTION
Use split_once() instead of split() as we only care for the first occurence of colon and whitespace.
Also added some tests to ensure proper behavior.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
